### PR TITLE
feat(admin,#3492): big overhaul of the SNAPI admin panel

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -5,7 +5,9 @@ from django.contrib import admin
 from django.http import HttpRequest, HttpResponse
 from django.utils.html import format_html
 from django.utils.safestring import SafeString
-from jet.filters import RelatedFieldAjaxListFilter
+
+# ignore the type error as it seems there's no package for it
+from jet.filters import RelatedFieldAjaxListFilter  # type: ignore
 
 from api.models import Article, Blog, Event, Launch, NewsSite, Provider, Report
 from api.models.abc import NewsItem
@@ -149,9 +151,9 @@ class ArticleAdmin(admin.ModelAdmin[NewsItem]):
         """Returns the image of the article."""
         return format_html('<img src="{}" width=50%/>', obj.image_url)
 
-    def changelist_view(self: "ArticleAdmin", request: HttpRequest, extra_context=None) -> HttpResponse:
+    def changelist_view(self, request: HttpRequest, extra_context: dict[str, str] | None = None) -> HttpResponse:
         extra_context = {"title": "News"}
-        return super().changelist_view(request, extra_context=extra_context)
+        return super().changelist_view(request, extra_context)
 
 
 @admin.register(Report)
@@ -167,9 +169,9 @@ class ReportAdmin(admin.ModelAdmin[Report]):
 class NewsSiteAdmin(admin.ModelAdmin[NewsSite]):
     list_display = ("name", "id")
 
-    def changelist_view(self: "NewsSiteAdmin", request: HttpRequest, extra_context=None) -> HttpResponse:
+    def changelist_view(self, request: HttpRequest, extra_context: dict[str, str] | None = None) -> HttpResponse:
         extra_context = {"title": "News Sites"}
-        return super().changelist_view(request, extra_context=extra_context)
+        return super().changelist_view(request, extra_context)
 
 
 # Models that can be registered as is

--- a/api/admin.py
+++ b/api/admin.py
@@ -144,7 +144,7 @@ class ArticleAdmin(admin.ModelAdmin[NewsItem]):
 
     def changelist_view(self, request, extra_context=None) -> HttpResponse:
         extra_context = {"title": "News"}
-        return super(ArticleAdmin, self).changelist_view(request, extra_context=extra_context)
+        return super().changelist_view(request, extra_context=extra_context)
 
 
 @admin.register(Report)
@@ -162,7 +162,7 @@ class NewsSiteAdmin(admin.ModelAdmin[NewsSite]):
 
     def changelist_view(self, request, extra_context=None):
         extra_context = {"title": "News Sites"}
-        return super(NewsSiteAdmin, self).changelist_view(request, extra_context=extra_context)
+        return super().changelist_view(request, extra_context=extra_context)
 
 
 # Models that can be registered as is

--- a/api/admin.py
+++ b/api/admin.py
@@ -2,7 +2,7 @@
 
 from django import forms
 from django.contrib import admin
-from django.http import HttpResponse, HttpRequest
+from django.http import HttpRequest, HttpResponse
 from django.utils.html import format_html
 from django.utils.safestring import SafeString
 from jet.filters import RelatedFieldAjaxListFilter

--- a/api/admin.py
+++ b/api/admin.py
@@ -1,4 +1,5 @@
 """Custom admin views for the Spaceflight News API."""
+
 from django import forms
 from django.contrib import admin
 from django.http import HttpResponse
@@ -38,7 +39,7 @@ class ArticleAdmin(admin.ModelAdmin[NewsItem]):
         ("events", RelatedFieldAjaxListFilter),
         "published_at",
         "featured",
-        "is_deleted"
+        "is_deleted",
     )
     search_fields = ["title"]
     ordering = ("-published_at",)

--- a/api/admin.py
+++ b/api/admin.py
@@ -2,7 +2,7 @@
 
 from django import forms
 from django.contrib import admin
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpRequest
 from django.utils.html import format_html
 from django.utils.safestring import SafeString
 from jet.filters import RelatedFieldAjaxListFilter
@@ -11,7 +11,7 @@ from api.models import Article, Blog, Event, Launch, NewsSite, Provider, Report
 from api.models.abc import NewsItem
 
 
-class ArticleForm(forms.ModelForm):
+class ArticleForm(forms.ModelForm[NewsItem]):
     title = forms.CharField(widget=forms.TextInput(attrs={"size": 70}), required=True)
 
 
@@ -137,13 +137,14 @@ class ArticleAdmin(admin.ModelAdmin[NewsItem]):
         "D",
     )
 
-    def image_tag(self, obj) -> SafeString:
+    @staticmethod
+    def image_tag(obj) -> SafeString:
         """Returns the image of the article."""
         return format_html('<img src="{}" width=50%/>', obj.image_url)
 
     image_tag.short_description = "Image"
 
-    def changelist_view(self, request, extra_context=None) -> HttpResponse:
+    def changelist_view(self, request: HttpRequest, extra_context=None) -> HttpResponse:
         extra_context = {"title": "News"}
         return super().changelist_view(request, extra_context=extra_context)
 

--- a/api/admin.py
+++ b/api/admin.py
@@ -1,11 +1,17 @@
 """Custom admin views for the Spaceflight News API."""
-
+from django import forms
 from django.contrib import admin
-from django.db.models import Count, QuerySet
-from django.http import HttpRequest
+from django.http import HttpResponse
+from django.utils.html import format_html
+from django.utils.safestring import SafeString
+from jet.filters import RelatedFieldAjaxListFilter
 
 from api.models import Article, Blog, Event, Launch, NewsSite, Provider, Report
 from api.models.abc import NewsItem
+
+
+class ArticleForm(forms.ModelForm):
+    title = forms.CharField(widget=forms.TextInput(attrs={"size": 70}), required=True)
 
 
 # Register your models here.
@@ -15,34 +21,130 @@ from api.models.abc import NewsItem
 class ArticleAdmin(admin.ModelAdmin[NewsItem]):
     """Admin view for articles and blogs."""
 
+    list_per_page = 30
+    form = ArticleForm
     list_display = (
         "title",
-        "news_site",
-        "published_at",
-        "featured",
+        "published_at_formatted",
+        "news_site_formatted",
         "assigned_launches",
         "assigned_events",
-        "is_deleted",
+        "featured_formatted",
+        "is_deleted_formatted",
     )
-    list_filter = ("published_at", "featured", "news_site", "is_deleted")
-    filter_horizontal = ["launches", "events"]
+    list_filter = (
+        ("news_site", RelatedFieldAjaxListFilter),
+        ("launches", RelatedFieldAjaxListFilter),
+        ("events", RelatedFieldAjaxListFilter),
+        "published_at",
+        "featured",
+        "is_deleted"
+    )
     search_fields = ["title"]
     ordering = ("-published_at",)
+    readonly_fields = [
+        "image_tag",
+    ]
+    fields = [
+        "title",
+        "url",
+        "news_site",
+        "summary",
+        "published_at",
+        "featured",
+        "launches",
+        "events",
+        "is_deleted",
+        "image_tag",
+    ]
 
     @staticmethod
-    def assigned_launches(obj: NewsItem) -> int:
+    def published_at_formatted(obj: NewsItem) -> str:
+        """Returns the publication datetime as a formatted string."""
+        return obj.published_at.strftime("%B %d, %Y – %H:%M")
+
+    published_at_formatted.short_description = "Published at"
+    published_at_formatted.admin_order_field = "published_at"
+
+    @staticmethod
+    def news_site_formatted(obj: NewsItem) -> SafeString:
+        """Returns the news site as a hyperlink to the article page."""
+        return format_html('<a href="{}">{}</a>', obj.url, obj.news_site)
+
+    news_site_formatted.short_description = "News site"
+    news_site_formatted.admin_order_field = "news_site"
+
+    @staticmethod
+    def assigned_launches(obj: NewsItem) -> SafeString:
         """Returns the number of launches assigned to the article."""
-        return obj.launches.count()
+        count = obj.launches.count()
+        if count == 0:
+            return format_html("")
+        return format_html(
+            '<div  title="{}" style="text-align:center;background:LawnGreen;color:black">{}</div >',
+            "\n".join(obj.launches.values_list("name", flat=True)),
+            obj.launches.count(),
+        )
+
+    assigned_launches.short_description = format_html(
+        '<div  title="{}">{}</div >',
+        "LL2 Launches",
+        "L",
+    )
 
     @staticmethod
-    def assigned_events(obj: NewsItem) -> int:
+    def assigned_events(obj: NewsItem) -> SafeString:
         """Returns the number of events assigned to the article."""
-        return obj.events.count()
+        count = obj.events.count()
+        if count == 0:
+            return format_html("")
+        return format_html(
+            '<div  title="{}" style="text-align:center;background:PaleTurquoise;color:black">{}</div >',
+            "\n".join(obj.events.values_list("name", flat=True)),
+            obj.events.count(),
+        )
 
-    def get_queryset(self, request: HttpRequest) -> QuerySet[NewsItem]:
-        queryset = super().get_queryset(request)
-        queryset = queryset.annotate(launch_count=Count("launches"), event_count=Count("events"))
-        return queryset
+    assigned_events.short_description = format_html(
+        '<div  title="{}">{}</div >',
+        "LL2 Events",
+        "E",
+    )
+
+    @staticmethod
+    def featured_formatted(obj: NewsItem) -> bool:
+        """Returns whether the article is featured."""
+        return obj.featured
+
+    featured_formatted.boolean = True
+    featured_formatted.admin_order_field = "featured"
+    featured_formatted.short_description = format_html(
+        '<div  title="{}">{}</div >',
+        "Featured",
+        "F",
+    )
+
+    @staticmethod
+    def is_deleted_formatted(obj: NewsItem) -> bool:
+        """Returns whether the article is hidden from the API response."""
+        return obj.is_deleted
+
+    featured_formatted.boolean = True
+    featured_formatted.admin_order_field = "is_deleted"
+    featured_formatted.short_description = format_html(
+        '<div  title="{}">{}</div >',
+        "Deleted",
+        "D",
+    )
+
+    def image_tag(self, obj) -> SafeString:
+        """Returns the image of the article."""
+        return format_html('<img src="{}" width=50%/>', obj.image_url)
+
+    image_tag.short_description = "Image"
+
+    def changelist_view(self, request, extra_context=None) -> HttpResponse:
+        extra_context = {"title": "News"}
+        return super(ArticleAdmin, self).changelist_view(request, extra_context=extra_context)
 
 
 @admin.register(Report)
@@ -57,6 +159,10 @@ class ReportAdmin(admin.ModelAdmin[Report]):
 @admin.register(NewsSite)
 class NewsSiteAdmin(admin.ModelAdmin[NewsSite]):
     list_display = ("name", "id")
+
+    def changelist_view(self, request, extra_context=None):
+        extra_context = {"title": "News Sites"}
+        return super(NewsSiteAdmin, self).changelist_view(request, extra_context=extra_context)
 
 
 # Models that can be registered as is
@@ -75,6 +181,6 @@ class LaunchAdmin(admin.ModelAdmin[Launch]):
 admin.site.register(Provider)
 
 # Other customizations
-admin.site.site_title = "Spaceflight News API Admin"
-admin.site.site_header = "Spaceflight News API Admin"
-admin.site.index_title = "Spaceflight News API Admin"
+admin.site.site_title = "SNAPI Admin"
+admin.site.site_header = "SNAPI Admin"
+admin.site.index_title = "Home"

--- a/api/admin.py
+++ b/api/admin.py
@@ -138,13 +138,13 @@ class ArticleAdmin(admin.ModelAdmin[NewsItem]):
     )
 
     @staticmethod
-    def image_tag(obj) -> SafeString:
+    def image_tag(obj: NewsItem) -> SafeString:
         """Returns the image of the article."""
         return format_html('<img src="{}" width=50%/>', obj.image_url)
 
     image_tag.short_description = "Image"
 
-    def changelist_view(self, request: HttpRequest, extra_context=None) -> HttpResponse:
+    def changelist_view(self: "ArticleAdmin", request: HttpRequest, extra_context=None) -> HttpResponse:
         extra_context = {"title": "News"}
         return super().changelist_view(request, extra_context=extra_context)
 
@@ -162,7 +162,7 @@ class ReportAdmin(admin.ModelAdmin[Report]):
 class NewsSiteAdmin(admin.ModelAdmin[NewsSite]):
     list_display = ("name", "id")
 
-    def changelist_view(self, request, extra_context=None):
+    def changelist_view(self: "NewsSiteAdmin", request: HttpRequest, extra_context=None) -> HttpResponse:
         extra_context = {"title": "News Sites"}
         return super().changelist_view(request, extra_context=extra_context)
 

--- a/api/admin.py
+++ b/api/admin.py
@@ -60,22 +60,31 @@ class ArticleAdmin(admin.ModelAdmin[NewsItem]):
     ]
 
     @staticmethod
+    @admin.display(
+        ordering="-published_at",
+        description="Published at",
+    )
     def published_at_formatted(obj: NewsItem) -> str:
         """Returns the publication datetime as a formatted string."""
         return obj.published_at.strftime("%B %d, %Y – %H:%M")
 
-    published_at_formatted.short_description = "Published at"
-    published_at_formatted.admin_order_field = "published_at"
-
     @staticmethod
+    @admin.display(
+        ordering="news_site",
+        description="News site",
+    )
     def news_site_formatted(obj: NewsItem) -> SafeString:
         """Returns the news site as a hyperlink to the article page."""
         return format_html('<a href="{}">{}</a>', obj.url, obj.news_site)
 
-    news_site_formatted.short_description = "News site"
-    news_site_formatted.admin_order_field = "news_site"
-
     @staticmethod
+    @admin.display(
+        description=format_html(
+            '<div  title="{}">{}</div >',
+            "LL2 Launches",
+            "L",
+        ),
+    )
     def assigned_launches(obj: NewsItem) -> SafeString:
         """Returns the number of launches assigned to the article."""
         count = obj.launches.count()
@@ -87,13 +96,14 @@ class ArticleAdmin(admin.ModelAdmin[NewsItem]):
             obj.launches.count(),
         )
 
-    assigned_launches.short_description = format_html(
-        '<div  title="{}">{}</div >',
-        "LL2 Launches",
-        "L",
-    )
-
     @staticmethod
+    @admin.display(
+        description=format_html(
+            '<div  title="{}">{}</div >',
+            "LL2 Events",
+            "E",
+        )
+    )
     def assigned_events(obj: NewsItem) -> SafeString:
         """Returns the number of events assigned to the article."""
         count = obj.events.count()
@@ -105,44 +115,39 @@ class ArticleAdmin(admin.ModelAdmin[NewsItem]):
             obj.events.count(),
         )
 
-    assigned_events.short_description = format_html(
-        '<div  title="{}">{}</div >',
-        "LL2 Events",
-        "E",
-    )
-
     @staticmethod
+    @admin.display(
+        boolean=True,
+        ordering="featured",
+        description=format_html(
+            '<div  title="{}">{}</div >',
+            "Featured",
+            "F",
+        ),
+    )
     def featured_formatted(obj: NewsItem) -> bool:
         """Returns whether the article is featured."""
         return obj.featured
 
-    featured_formatted.boolean = True
-    featured_formatted.admin_order_field = "featured"
-    featured_formatted.short_description = format_html(
-        '<div  title="{}">{}</div >',
-        "Featured",
-        "F",
-    )
-
     @staticmethod
+    @admin.display(
+        boolean=True,
+        ordering="is_deleted",
+        description=format_html(
+            '<div  title="{}">{}</div >',
+            "Deleted",
+            "D",
+        ),
+    )
     def is_deleted_formatted(obj: NewsItem) -> bool:
         """Returns whether the article is hidden from the API response."""
         return obj.is_deleted
 
-    featured_formatted.boolean = True
-    featured_formatted.admin_order_field = "is_deleted"
-    featured_formatted.short_description = format_html(
-        '<div  title="{}">{}</div >',
-        "Deleted",
-        "D",
-    )
-
     @staticmethod
+    @admin.display(description="Image")
     def image_tag(obj: NewsItem) -> SafeString:
         """Returns the image of the article."""
         return format_html('<img src="{}" width=50%/>', obj.image_url)
-
-    image_tag.short_description = "Image"
 
     def changelist_view(self: "ArticleAdmin", request: HttpRequest, extra_context=None) -> HttpResponse:
         extra_context = {"title": "News"}

--- a/api/models/news_site.py
+++ b/api/models/news_site.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from django.db import models
 
 
@@ -6,3 +8,7 @@ class NewsSite(models.Model):
 
     def __str__(self) -> str:
         return self.name
+
+    @staticmethod
+    def autocomplete_search_fields() -> tuple[Literal["name"],]:
+        return ("name",)


### PR DESCRIPTION
Closes #3492

Changes to to the SNAPI admin panel.
Please test them and tick correspondingly @derkweijers.
- [x] Limit to 30 items
- [x] Make title field form wider
- [x] Change order of columns
- [x] Shorten `assigned launches` and `assigned events` columns headers (add description in tooltip), add tooltip with list of objects linked on hover of the value, add colored backgrounds and hide `0` value to make those with objects linked more visible
- [x] Shorten `featured` and `is deleted` column headers (add descriptions in tooltip)
- [x] Custom date/time format
- [x] Autocomplete AJAX filters for new sites, launches, and events
- [x] Use `news_site` column as hyperlinks to the article/blog url
- [x] Preview of the article/blog image in the edit view
- [x] Change admin homepage name to `SNAPI Admin`
- [x] Change web browser tab name to `[ ] | SNAPI Admin`, where `[ ]` is `News` for `ArticleAdmin` and `News Sites` for `NewsSiteAdmin`.
- [x] Remove unneeded code (launch/event count annotations in queryset, horizontal filter from old admin, ...)