### PR TITLE
fix(admin): add `image_url` field to news items admin

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -51,6 +51,7 @@ class ArticleAdmin(admin.ModelAdmin[NewsItem]):
     fields = [
         "title",
         "url",
+        "image_url",
         "news_site",
         "summary",
         "published_at",


### PR DESCRIPTION
Can't properly manually add articles without that 😅 