### PR TITLE
Add prefetch for authors__socials to fix N+1 query issue

### DIFF
--- a/src/api/views/articles.py
+++ b/src/api/views/articles.py
@@ -9,7 +9,7 @@ from api.views.filters import DocsFilter, SearchFilter
 class ArticleViewSet(viewsets.ReadOnlyModelViewSet):  # type: ignore
     queryset = (
         Article.objects.exclude(is_deleted=True)
-        .prefetch_related("launches", "events", "authors")
+        .prefetch_related("launches", "events", "authors", "authors__socials")
         .select_related("news_site")
         .order_by("-published_at")
     )

--- a/src/api/views/blogs.py
+++ b/src/api/views/blogs.py
@@ -9,7 +9,7 @@ from api.views.filters import DocsFilter, SearchFilter
 class BlogViewSet(viewsets.ReadOnlyModelViewSet):  # type: ignore
     queryset = (
         Blog.objects.exclude(is_deleted=True)
-        .prefetch_related("launches", "events", "authors")
+        .prefetch_related("launches", "events", "authors", "authors__socials")
         .select_related("news_site")
         .order_by("-published_at")
     )

--- a/src/api/views/reports.py
+++ b/src/api/views/reports.py
@@ -10,7 +10,7 @@ class ReportViewSet(viewsets.ReadOnlyModelViewSet):  # type: ignore
     queryset = (
         Report.objects.exclude(is_deleted=True)
         .select_related("news_site")
-        .prefetch_related("authors")
+        .prefetch_related("authors", "authors__socials")
         .order_by("-published_at")
     )
     serializer_class = ReportSerializer


### PR DESCRIPTION
The article, blog, and report viewsets were prefetching authors but not their related socials objects. This caused an individual SELECT query on api_socials for every author, exhausting database connections under load.